### PR TITLE
32-bitcheck v1.6 - stylefixes

### DIFF
--- a/Casks/32-bitcheck.rb
+++ b/Casks/32-bitcheck.rb
@@ -2,12 +2,12 @@ cask '32-bitcheck' do
   version '1.6'
   sha256 '21950b84198074da3d98ecd0911cfafff56d1005b30621706aa87300dd54c3a7'
 
-  # eclecticlightdotcom.files.wordpress.com/ was verified as official when first introduced to the cask
+  # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url 'https://eclecticlightdotcom.files.wordpress.com/2018/08/32bitcheck16.zip'
   name '32-bitCheck'
-  homepage 'https://eclecticlight.co/2018/11/02/systhist-1-6-fixes-recognition-of-mojave-updates/'
+  homepage 'https://eclecticlight.co/'
 
-  depends_on macos: '>= 10.11'
+  depends_on macos: '>= :el_capitan'
 
   app '32bitCheck16/32-bitCheck.app'
 end


### PR DESCRIPTION
Fixes to formula:  
- updated comment for URL stanza
- updated homepage 
- changed macOS version dependency to human-readable format

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.