### PR TITLE
Fixed `depends_on` stanza for consolation3.rb

### DIFF
--- a/Casks/consolation3.rb
+++ b/Casks/consolation3.rb
@@ -7,7 +7,7 @@ cask 'consolation3' do
   name 'Consolation3'
   homepage 'https://eclecticlight.co/'
 
-  depends_on macos: [:sierra, :high_sierra]
+  depends_on macos: '>= :sierra'
 
   app 'consolation3b17/Consolation3.app'
 end


### PR DESCRIPTION
Corrected macOS dependency to require Sierra and above, not just Sierra & High Sierra. 