### PR TITLE
Stanza updates

### DIFF
--- a/Casks/t2m2.rb
+++ b/Casks/t2m2.rb
@@ -1,14 +1,14 @@
 cask 't2m2' do
-  version '1.4'
+  version '1.4,2018.10'
   sha256 '7685cc815b73aa2306f55a5b43e0554a18f22b3724a85372358de83ead41d311'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
-  url 'https://eclecticlightdotcom.files.wordpress.com/2018/10/t2m214.zip'
+  url 'https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/t2m2#{version.before_comma.major}#{version.before_comma.minor}.zip'
   name 't2m2'
   name 'TheTimeMachineMechanic'
-  homepage 'https://eclecticlight.co/2018/10/24/checking-time-machine-in-mojave-and-high-sierra-using-t2m2-1-4/'
+  homepage 'https://eclecticlight.co/'
 
   depends_on macos: '>= :sierra'
 
-  app 't2m214/TheTimeMachineMechanic.app'
+  app 't2m2#{version.before_comma.major}#{version.before_comma.minor}/TheTimeMachineMechanic.app'
 end


### PR DESCRIPTION
- updated `version` `url` and `app` stanzas to be consistent with [lockrattler](https://github.com/Homebrew/homebrew-cask/blob/5aea457062b7db84fff0e1a03ea6be5becf790b6/Casks/lockrattler.rb#L6) in the official cask repo.
- cleaned up the `homepage` stanza.