### PR TITLE
Alifix 1.0b2 fix

### DIFF
--- a/Casks/alifix.rb
+++ b/Casks/alifix.rb
@@ -3,11 +3,15 @@ cask 'alifix' do
   sha256 '9d6dc63c3ab9f9885e770f7c1130c3cd6c44944776904245eee847cff459ca71'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
-  url 'https://https://eclecticlightdotcom.files.wordpress.com/2019/01/alifix10b2.zip'
+  url 'https://eclecticlightdotcom.files.wordpress.com/2019/01/alifix10b2.zip'
   name 'alifix'
   homepage 'https://eclecticlight.co/downloads/'
 
   depends_on macos: '>= :sierra'
 
   app 'alifix10b2/Alifix.app'
+
+  caveats do
+    "Additional documentation about how to use #{token} can be found at #{staged_path}"
+  end
 end


### PR DESCRIPTION
Fixes #30  where line 6 has `https://` twice causing the cask to not 
download

Also added a `caveats` stanza to let users know where additional 
documentation can be located.