### PR TITLE
Fixes to taccy.rb

### DIFF
--- a/Casks/taccy.rb
+++ b/Casks/taccy.rb
@@ -1,13 +1,15 @@
 cask 'taccy' do
-  version '1.20b7'
+  version "1.0b7,2019.01"
   sha256 '3c6beef36c7230f29d8852e63bc0a7999be4829f2bcb8790dc29df961296e54c'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
-  url 'https://eclecticlightdotcom.files.wordpress.com/2019/01/taccy10b7.zip'
+  url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/#{version.before_comma.major}#{version.before_comma.minor}.zip"
   name 'Taccy'
   homepage 'https://eclecticlight.co/'
 
   depends_on macos: '>= :sierra'
 
-  app 'taccy10b7/Taccy.app'
+  app "taccy#{version.before_comma.major}#{version.before_comma.minor}/Taccy.app"
+  
+  caveats "Additional documentation about #{token} and its usage can be found at #{staged_path}"
 end

--- a/Casks/taccy.rb
+++ b/Casks/taccy.rb
@@ -1,9 +1,9 @@
 cask 'taccy' do
-  version "1.0b7,2019.01"
+  version '1.0b7,2019.01'
   sha256 '3c6beef36c7230f29d8852e63bc0a7999be4829f2bcb8790dc29df961296e54c'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
-  url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/#{version.before_comma.major}#{version.before_comma.minor}.zip"
+  url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/taccy#{version.before_comma.no_dots}.zip"
   name 'Taccy'
   homepage 'https://eclecticlight.co/'
 

--- a/Casks/taccy.rb
+++ b/Casks/taccy.rb
@@ -9,7 +9,7 @@ cask 'taccy' do
 
   depends_on macos: '>= :sierra'
 
-  app "taccy#{version.before_comma.major}#{version.before_comma.minor}/Taccy.app"
+  app "taccy#{version.before_comma.no_dots}/Taccy.app"
   
   caveats "Additional documentation about #{token} and its usage can be found at #{staged_path}"
 end

--- a/Casks/taccy.rb
+++ b/Casks/taccy.rb
@@ -8,7 +8,7 @@ cask 'taccy' do
   homepage 'https://eclecticlight.co/'
 
   depends_on macos: '>= :sierra'
-
+  
   app "taccy#{version.before_comma.no_dots}/Taccy.app"
   
   caveats "Additional documentation about #{token} and its usage can be found at #{staged_path}"


### PR DESCRIPTION
- fixes a typo in `version` stanza
- updates cask go semantic versioning 
- adds `caveats` stanza