### PR TITLE
Add config for houndci

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+rubocop:
+  enabled: true
+  config_file: rubocop.yml
+  version: 0.80.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+inheret_from:
+  - https://github.com/Homebrew/brew/blob/master/Library/.rubocop.yml
+  - https://github.com/Homebrew/brew/blob/master/Library/.rubocop_cask.yml
+  - https://github.com/Homebrew/brew/blob/master/Library/.rubocop_shared.yml


### PR DESCRIPTION
Added `.rubocop.yml` with links to the configs used by homebrew to see if I can avoid the line-length comment.